### PR TITLE
fix: prevent cast for number with leading zero in strings

### DIFF
--- a/src/cast.js
+++ b/src/cast.js
@@ -7,6 +7,10 @@ export default (value) => {
     }
 
     if (false === isNaN(value)) {
+        if ('string' === typeof value && value.startsWith('0')) {
+            return value;
+        }
+
         return Number.isInteger(value) ? parseInt(value) : parseFloat(value);
     }
 

--- a/tests/cast.test.js
+++ b/tests/cast.test.js
@@ -14,6 +14,10 @@ test('Booleans in strings are casted', () => {
     expect(cast('off')).toBe(false);
 });
 
+test('Number values with leading 0 in strings are left intact', () => {
+    expect(cast('007')).toBe('007');
+});
+
 test('Other values are left intact', () => {
     expect(cast('foo')).toBe('foo');
     expect(cast(['foo'])).toStrictEqual(['foo']);


### PR DESCRIPTION
Currently, the number with leading 0 is cast to number with `parseFloat`.

With this PR, `007` are left intact.